### PR TITLE
エネミーの視界の判定処理を作成

### DIFF
--- a/pro_builder_test/Assets/Mitsumaru/Scripts/EnemyVisibility.cs
+++ b/pro_builder_test/Assets/Mitsumaru/Scripts/EnemyVisibility.cs
@@ -1,0 +1,89 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// 敵の視界の処理を行う
+/// </summary
+public class EnemyVisibility : MonoBehaviour
+{
+    // プレイヤー
+    [SerializeField]
+    Transform player = default;
+
+    // 視界の角度
+    [SerializeField]
+    [Range(0, 180)]
+    float angle = 10;
+
+    // 視界の距離
+    [SerializeField]
+    float distance = 0;
+
+    // 視界の左側の境界
+    Vector3 leftBorder = Vector3.zero;
+    // 視界の右側の境界
+    Vector3 rightBorder = Vector3.zero;
+
+    /// <summary>
+    /// 更新
+    /// </summary>
+    void Update()
+    {
+        // 境界ベクトルを作成
+        CreateBorderVector();
+    }
+
+    /// <summary>
+    /// 視界の境界ベクトルを作成
+    /// </summary>
+    void CreateBorderVector()
+    {
+        // 左側の境界ベクトル
+        Vector3 leftVec = Quaternion.Euler(0, -angle * 0.5f, 0) * transform.forward;
+        // 視界の距離だけベクトルを伸ばす
+        leftBorder = leftVec * distance;
+
+        // 右側の境界ベクトル
+        Vector3 rightVec = Quaternion.Euler(0, angle * 0.5f, 0) * transform.forward;
+        // 視界の距離だけベクトルを伸ばす
+        rightBorder = rightVec * distance;
+    }
+
+    /// <summary>
+    /// プレイヤーを発見しているかどうか
+    /// </summary>
+    /// <returns>発見中かどうかのフラグ</returns>
+    public bool IsPlayerDiscover()
+    {
+        // プレイヤーとエネミーとのベクトルを算出
+        Vector3 playerToEnemy = player.transform.position - transform.position;
+        // 算出したベクトルとプレイヤーの向きベクトルの角度を算出
+        float dot = Vector3.Angle(transform.forward, playerToEnemy.normalized);
+
+        // [条件１]
+        // 算出した角度が左右の境界ベクトルよりも傾いているかどうか
+        // memo : 傾いている→視界の範囲外　傾いていない→視界の範囲内
+        // [条件２]
+        // プレイヤーとエネミーの距離が視界の距離よりも離れているかどうか
+        // memo : 離れている→視界の範囲外　離れていない→視界の範囲内
+        if (dot < (angle * 0.5f) && playerToEnemy.sqrMagnitude < distance * distance)
+        {
+            // プレイヤーを見つけた
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Sceneビューのみに表示
+    /// </summary>
+    void OnDrawGizmos()
+    {
+        // 境界ベクトルを作成
+        CreateBorderVector();
+        // デバッグ用に境界ベクトルを表示する
+        Debug.DrawRay(transform.position, leftBorder, Color.green);
+        Debug.DrawRay(transform.position, rightBorder, Color.green);
+    }
+}

--- a/pro_builder_test/Assets/Mitsumaru/Scripts/EnemyVisibility.cs.meta
+++ b/pro_builder_test/Assets/Mitsumaru/Scripts/EnemyVisibility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 90b577ef2a7fffe4293efe85a773f094
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/pro_builder_test/Assets/Mitsumaru/Scripts/PlayerMoverTest.cs
+++ b/pro_builder_test/Assets/Mitsumaru/Scripts/PlayerMoverTest.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// テスト用のプレイヤーの移動処理
+/// （プレイヤーにみたてたオブジェクトを移動させるだけ）
+/// </summary>
+public class PlayerMoverTest : MonoBehaviour
+{
+    // 移動スピード
+    [SerializeField]
+    float speed = 0;
+
+    /// <summary>
+    /// 更新
+    /// </summary>
+    void Update()
+    {
+        // 向き
+        Vector3 direction = Vector3.zero;
+
+        // キー入力
+        if (Input.GetKey(KeyCode.UpArrow))    { direction.z++; }
+        if (Input.GetKey(KeyCode.DownArrow))  { direction.z--; }
+        if (Input.GetKey(KeyCode.LeftArrow))  { direction.x--; }
+        if (Input.GetKey(KeyCode.RightArrow)) { direction.x++; }
+
+        // 正規化
+        direction = direction.normalized;
+        // 向きに移動量を加える
+        Vector3 velocity = direction * speed;
+        // 移動する
+        transform.position += velocity;
+    }
+}

--- a/pro_builder_test/Assets/Mitsumaru/Scripts/PlayerMoverTest.cs.meta
+++ b/pro_builder_test/Assets/Mitsumaru/Scripts/PlayerMoverTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: aca08b7443c8bc34e81532faa24eb927
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/pro_builder_test/Assets/Mitsumaru/TestScene_Mitsumaru.unity
+++ b/pro_builder_test/Assets/Mitsumaru/TestScene_Mitsumaru.unity
@@ -126,6 +126,39 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 736528487}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &108899793
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 108899794}
+  m_Layer: 0
+  m_Name: Behavior
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &108899794
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 108899793}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1355318080}
+  - {fileID: 756798316}
+  - {fileID: 2105149116}
+  m_Father: {fileID: 283617944}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &126985832 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 938179186347872562, guid: 8b9192f355793c2438107ca19a4a26ee,
@@ -190,29 +223,30 @@ GameObject:
   - component: {fileID: 283617944}
   - component: {fileID: 283617943}
   - component: {fileID: 283617942}
-  - component: {fileID: 283617941}
   - component: {fileID: 283617947}
-  - component: {fileID: 283617945}
+  - component: {fileID: 283617941}
   m_Layer: 0
-  m_Name: Enemy(Mover)
+  m_Name: Enemy
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!135 &283617941
-SphereCollider:
+--- !u!114 &283617941
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 283617940}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
   m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.5
-  m_Center: {x: 0, y: 0, z: 0}
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 90b577ef2a7fffe4293efe85a773f094, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  player: {fileID: 1971433529}
+  angle: 45
+  distance: 3.5
 --- !u!23 &283617942
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -267,31 +301,14 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 283617940}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 12.45, y: 2.96, z: 16.37}
+  m_LocalPosition: {x: 21.74, y: 2.96, z: 21.08}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 108899794}
+  - {fileID: 1825367445}
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &283617945
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 283617940}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 75163a55b13402b4aab05c288152c845, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  navMeshAgent: {fileID: 283617947}
-  targetPositions:
-  - {x: 14.29, y: 0, z: 17.7}
-  - {x: 3.6, y: 0, z: 25.13}
-  - {x: -17.71, y: 0, z: 11.71}
-  - {x: -14, y: 0, z: 2.8}
-  - {x: 3.75, y: 0, z: 9.07}
 --- !u!195 &283617947
 NavMeshAgent:
   m_ObjectHideFlags: 0
@@ -314,6 +331,50 @@ NavMeshAgent:
   m_BaseOffset: 0.5
   m_WalkableMask: 4294967295
   m_ObstacleAvoidanceType: 4
+--- !u!1 &432448698
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 432448699}
+  - component: {fileID: 432448700}
+  m_Layer: 0
+  m_Name: WarningArea
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &432448699
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 432448698}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1825367445}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!135 &432448700
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 432448698}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 1.5
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1001 &736528487
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -325,6 +386,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: house_01
+      objectReference: {fileID: 0}
+    - target: {fileID: -1647792432471558635, guid: 2051706574dadcb4da2f703efc0f9e5e,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: -4216859302048453862, guid: 2051706574dadcb4da2f703efc0f9e5e,
         type: 3}
@@ -381,13 +447,38 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -1647792432471558635, guid: 2051706574dadcb4da2f703efc0f9e5e,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 8
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2051706574dadcb4da2f703efc0f9e5e, type: 3}
+--- !u!1 &756798315
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 756798316}
+  m_Layer: 0
+  m_Name: Chaser
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &756798316
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 756798315}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 108899794}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &873186042
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -409,6 +500,16 @@ PrefabInstance:
         type: 3}
       propertyPath: m_IsActive
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 938179186347872562, guid: f8a563e2f9aa4864d9db25e6b2fcaae8,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 938179186347872562, guid: f8a563e2f9aa4864d9db25e6b2fcaae8,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 40
       objectReference: {fileID: 0}
     - target: {fileID: -4216859302048453862, guid: f8a563e2f9aa4864d9db25e6b2fcaae8,
         type: 3}
@@ -475,16 +576,6 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: a7d5e099bc64f6e4981612bb3c4de01d, type: 2}
-    - target: {fileID: 938179186347872562, guid: f8a563e2f9aa4864d9db25e6b2fcaae8,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 938179186347872562, guid: f8a563e2f9aa4864d9db25e6b2fcaae8,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 40
-      objectReference: {fileID: 0}
     - target: {fileID: -8258452029021908223, guid: f8a563e2f9aa4864d9db25e6b2fcaae8,
         type: 3}
       propertyPath: m_LocalPosition.y
@@ -534,27 +625,17 @@ PrefabInstance:
       propertyPath: m_StaticEditorFlags
       value: 4294967295
       objectReference: {fileID: 0}
-    - target: {fileID: -8709455722471484303, guid: 8b9192f355793c2438107ca19a4a26ee,
+    - target: {fileID: 7020929029430093381, guid: 8b9192f355793c2438107ca19a4a26ee,
         type: 3}
       propertyPath: m_StaticEditorFlags
       value: 4294967295
       objectReference: {fileID: 0}
-    - target: {fileID: -8157538160132782548, guid: 8b9192f355793c2438107ca19a4a26ee,
+    - target: {fileID: 7364474687380560130, guid: 8b9192f355793c2438107ca19a4a26ee,
         type: 3}
       propertyPath: m_StaticEditorFlags
       value: 4294967295
       objectReference: {fileID: 0}
-    - target: {fileID: -8054765929006606332, guid: 8b9192f355793c2438107ca19a4a26ee,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 4294967295
-      objectReference: {fileID: 0}
-    - target: {fileID: -6768980184500594509, guid: 8b9192f355793c2438107ca19a4a26ee,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 4294967295
-      objectReference: {fileID: 0}
-    - target: {fileID: -6587267371808459487, guid: 8b9192f355793c2438107ca19a4a26ee,
+    - target: {fileID: -2678621176253827910, guid: 8b9192f355793c2438107ca19a4a26ee,
         type: 3}
       propertyPath: m_StaticEditorFlags
       value: 4294967295
@@ -564,22 +645,12 @@ PrefabInstance:
       propertyPath: m_StaticEditorFlags
       value: 4294967295
       objectReference: {fileID: 0}
-    - target: {fileID: -5795078470798012607, guid: 8b9192f355793c2438107ca19a4a26ee,
+    - target: {fileID: -175566814362028823, guid: 8b9192f355793c2438107ca19a4a26ee,
         type: 3}
       propertyPath: m_StaticEditorFlags
       value: 4294967295
       objectReference: {fileID: 0}
-    - target: {fileID: -5279648558848880324, guid: 8b9192f355793c2438107ca19a4a26ee,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 4294967295
-      objectReference: {fileID: 0}
-    - target: {fileID: -5162198296508653919, guid: 8b9192f355793c2438107ca19a4a26ee,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 4294967295
-      objectReference: {fileID: 0}
-    - target: {fileID: -4978963452970668571, guid: 8b9192f355793c2438107ca19a4a26ee,
+    - target: {fileID: -4817956294508754064, guid: 8b9192f355793c2438107ca19a4a26ee,
         type: 3}
       propertyPath: m_StaticEditorFlags
       value: 4294967295
@@ -589,7 +660,152 @@ PrefabInstance:
       propertyPath: m_StaticEditorFlags
       value: 4294967295
       objectReference: {fileID: 0}
-    - target: {fileID: -4817956294508754064, guid: 8b9192f355793c2438107ca19a4a26ee,
+    - target: {fileID: -5279648558848880324, guid: 8b9192f355793c2438107ca19a4a26ee,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: 8596705613334294762, guid: 8b9192f355793c2438107ca19a4a26ee,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: -8709455722471484303, guid: 8b9192f355793c2438107ca19a4a26ee,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: 2047371763144490410, guid: 8b9192f355793c2438107ca19a4a26ee,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: -8157538160132782548, guid: 8b9192f355793c2438107ca19a4a26ee,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: -2573713794364129358, guid: 8b9192f355793c2438107ca19a4a26ee,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: 4410722261821810291, guid: 8b9192f355793c2438107ca19a4a26ee,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: 6671466721049915657, guid: 8b9192f355793c2438107ca19a4a26ee,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: 7882402963346569107, guid: 8b9192f355793c2438107ca19a4a26ee,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: -1424775742145853497, guid: 8b9192f355793c2438107ca19a4a26ee,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: 6647132489981377178, guid: 8b9192f355793c2438107ca19a4a26ee,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: 3819159577955521088, guid: 8b9192f355793c2438107ca19a4a26ee,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650405289767438788, guid: 8b9192f355793c2438107ca19a4a26ee,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: -5795078470798012607, guid: 8b9192f355793c2438107ca19a4a26ee,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: 8769700785618937078, guid: 8b9192f355793c2438107ca19a4a26ee,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: -6768980184500594509, guid: 8b9192f355793c2438107ca19a4a26ee,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: 938179186347872562, guid: 8b9192f355793c2438107ca19a4a26ee,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: -5162198296508653919, guid: 8b9192f355793c2438107ca19a4a26ee,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: -498455647839162853, guid: 8b9192f355793c2438107ca19a4a26ee,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: -2109071831081116094, guid: 8b9192f355793c2438107ca19a4a26ee,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: 4012822278540320556, guid: 8b9192f355793c2438107ca19a4a26ee,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: -1931120525572595276, guid: 8b9192f355793c2438107ca19a4a26ee,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: -511593043984341317, guid: 8b9192f355793c2438107ca19a4a26ee,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: 7082494278171776267, guid: 8b9192f355793c2438107ca19a4a26ee,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: 1503103409868325502, guid: 8b9192f355793c2438107ca19a4a26ee,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: -1716834514892720606, guid: 8b9192f355793c2438107ca19a4a26ee,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: -1002960098451406228, guid: 8b9192f355793c2438107ca19a4a26ee,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: -8054765929006606332, guid: 8b9192f355793c2438107ca19a4a26ee,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: -6587267371808459487, guid: 8b9192f355793c2438107ca19a4a26ee,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: -4978963452970668571, guid: 8b9192f355793c2438107ca19a4a26ee,
         type: 3}
       propertyPath: m_StaticEditorFlags
       value: 4294967295
@@ -648,131 +864,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -2678621176253827910, guid: 8b9192f355793c2438107ca19a4a26ee,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 4294967295
-      objectReference: {fileID: 0}
-    - target: {fileID: -2573713794364129358, guid: 8b9192f355793c2438107ca19a4a26ee,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 4294967295
-      objectReference: {fileID: 0}
-    - target: {fileID: -2109071831081116094, guid: 8b9192f355793c2438107ca19a4a26ee,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 4294967295
-      objectReference: {fileID: 0}
-    - target: {fileID: -1931120525572595276, guid: 8b9192f355793c2438107ca19a4a26ee,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 4294967295
-      objectReference: {fileID: 0}
-    - target: {fileID: -1716834514892720606, guid: 8b9192f355793c2438107ca19a4a26ee,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 4294967295
-      objectReference: {fileID: 0}
-    - target: {fileID: -1424775742145853497, guid: 8b9192f355793c2438107ca19a4a26ee,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 4294967295
-      objectReference: {fileID: 0}
-    - target: {fileID: -1002960098451406228, guid: 8b9192f355793c2438107ca19a4a26ee,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 4294967295
-      objectReference: {fileID: 0}
-    - target: {fileID: -511593043984341317, guid: 8b9192f355793c2438107ca19a4a26ee,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 4294967295
-      objectReference: {fileID: 0}
-    - target: {fileID: -498455647839162853, guid: 8b9192f355793c2438107ca19a4a26ee,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 4294967295
-      objectReference: {fileID: 0}
-    - target: {fileID: -175566814362028823, guid: 8b9192f355793c2438107ca19a4a26ee,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 4294967295
-      objectReference: {fileID: 0}
-    - target: {fileID: 938179186347872562, guid: 8b9192f355793c2438107ca19a4a26ee,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 1503103409868325502, guid: 8b9192f355793c2438107ca19a4a26ee,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 4294967295
-      objectReference: {fileID: 0}
-    - target: {fileID: 1650405289767438788, guid: 8b9192f355793c2438107ca19a4a26ee,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 4294967295
-      objectReference: {fileID: 0}
-    - target: {fileID: 2047371763144490410, guid: 8b9192f355793c2438107ca19a4a26ee,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 4294967295
-      objectReference: {fileID: 0}
-    - target: {fileID: 3819159577955521088, guid: 8b9192f355793c2438107ca19a4a26ee,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 4294967295
-      objectReference: {fileID: 0}
-    - target: {fileID: 4012822278540320556, guid: 8b9192f355793c2438107ca19a4a26ee,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 4294967295
-      objectReference: {fileID: 0}
-    - target: {fileID: 4410722261821810291, guid: 8b9192f355793c2438107ca19a4a26ee,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 4294967295
-      objectReference: {fileID: 0}
-    - target: {fileID: 6647132489981377178, guid: 8b9192f355793c2438107ca19a4a26ee,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 4294967295
-      objectReference: {fileID: 0}
-    - target: {fileID: 6671466721049915657, guid: 8b9192f355793c2438107ca19a4a26ee,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 4294967295
-      objectReference: {fileID: 0}
-    - target: {fileID: 7020929029430093381, guid: 8b9192f355793c2438107ca19a4a26ee,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 4294967295
-      objectReference: {fileID: 0}
-    - target: {fileID: 7082494278171776267, guid: 8b9192f355793c2438107ca19a4a26ee,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 4294967295
-      objectReference: {fileID: 0}
-    - target: {fileID: 7364474687380560130, guid: 8b9192f355793c2438107ca19a4a26ee,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 4294967295
-      objectReference: {fileID: 0}
-    - target: {fileID: 7882402963346569107, guid: 8b9192f355793c2438107ca19a4a26ee,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 4294967295
-      objectReference: {fileID: 0}
-    - target: {fileID: 8596705613334294762, guid: 8b9192f355793c2438107ca19a4a26ee,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 4294967295
-      objectReference: {fileID: 0}
-    - target: {fileID: 8769700785618937078, guid: 8b9192f355793c2438107ca19a4a26ee,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 4294967295
       objectReference: {fileID: 0}
     - target: {fileID: 8568998755497832391, guid: 8b9192f355793c2438107ca19a4a26ee,
         type: 3}
@@ -936,6 +1027,56 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8b9192f355793c2438107ca19a4a26ee, type: 3}
+--- !u!1 &1355318079
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1355318080}
+  - component: {fileID: 1355318081}
+  m_Layer: 0
+  m_Name: Move
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1355318080
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1355318079}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 108899794}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1355318081
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1355318079}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75163a55b13402b4aab05c288152c845, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  navMeshAgent: {fileID: 283617947}
+  targetPositions:
+  - {x: 14.29, y: 0, z: 17.7}
+  - {x: 3.6, y: 0, z: 25.13}
+  - {x: -17.71, y: 0, z: 11.71}
+  - {x: -14, y: 0, z: 2.8}
+  - {x: 3.75, y: 0, z: 9.07}
 --- !u!1 &1731916098 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 938179186347872562, guid: f8a563e2f9aa4864d9db25e6b2fcaae8,
@@ -1130,6 +1271,160 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 79.36, y: -6.3320003, z: -6.7100005}
+--- !u!1 &1825367444
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1825367445}
+  m_Layer: 0
+  m_Name: Collider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1825367445
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1825367444}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 432448699}
+  m_Father: {fileID: 283617944}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1971433524
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1971433529}
+  - component: {fileID: 1971433528}
+  - component: {fileID: 1971433527}
+  - component: {fileID: 1971433526}
+  - component: {fileID: 1971433525}
+  - component: {fileID: 1971433530}
+  m_Layer: 0
+  m_Name: Player
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1971433525
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1971433524}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aca08b7443c8bc34e81532faa24eb927, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  speed: 0.1
+--- !u!65 &1971433526
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1971433524}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1971433527
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1971433524}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 949f0b7babda74a4cb7ebaa4bca24a57, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1971433528
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1971433524}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1971433529
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1971433524}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.28, y: 3.459, z: 8.55}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!54 &1971433530
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1971433524}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
 --- !u!4 &1972058649 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: -4216859302048453862, guid: 8b9192f355793c2438107ca19a4a26ee,
@@ -1142,3 +1437,33 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 873186042}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &2105149115
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2105149116}
+  m_Layer: 0
+  m_Name: Warning
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2105149116
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2105149115}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 108899794}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}


### PR DESCRIPTION
エネミーの視界を扇形で判定する処理を作成した。
当初はスフィアコライダーと扇形の範囲の両方で判定を行うつもりだったが、そもそもコライダーなしで判定できることに気が付いた。
エネミーの中心からベクトルを伸ばしており、そのベクトルをもとに判定を行っているため、エネミーのオブジェクトが半分以上範囲内に入っていないと視界に入っている扱いにならない。

仮のプレイヤー用にオブジェクトを移動させるだけのテストプログラムを作成した。

【確認ファイル】
EnemyVisibility.cs
PlayerMoveTest.cs