### PR TITLE
エネミーとプレイヤーとの間に障害物があるかの判定を追加

### DIFF
--- a/pro_builder_test/Assets/Mitsumaru/Scripts/EnemyVisibility.cs
+++ b/pro_builder_test/Assets/Mitsumaru/Scripts/EnemyVisibility.cs
@@ -32,6 +32,15 @@ public class EnemyVisibility : MonoBehaviour
     {
         // 境界ベクトルを作成
         CreateBorderVector();
+
+        if (IsPlayerDiscover())
+        {
+            Debug.Log("AAA");
+        }
+        else
+        {
+            Debug.Log("BBB");
+        }
     }
 
     /// <summary>
@@ -56,10 +65,20 @@ public class EnemyVisibility : MonoBehaviour
     /// <returns>発見中かどうかのフラグ</returns>
     public bool IsPlayerDiscover()
     {
-        // プレイヤーとエネミーとのベクトルを算出
-        Vector3 playerToEnemy = player.transform.position - transform.position;
-        // 算出したベクトルとプレイヤーの向きベクトルの角度を算出
-        float dot = Vector3.Angle(transform.forward, playerToEnemy.normalized);
+        // エネミーからプレイヤーに向かってレイを飛ばす
+        Ray ray = new Ray(transform.position,(player.transform.position - transform.position).normalized);
+        // レイにヒットしたコライダーの情報
+        RaycastHit raycastHit;
+
+        // レイにオブジェクトが当たったか
+        // 当たっていなければ判定終了
+        if (!Physics.Raycast(ray,out raycastHit)) { return false; }
+        // 当たったオブジェクトが障害物かどうか
+        // 障害物だった場合は判定終了
+        if (raycastHit.collider.name != player.name) { return false; }
+
+        // レイの向きベクトルとプレイヤーの向きベクトルの角度を算出
+        float dot = Vector3.Angle(transform.forward, ray.direction);
 
         // [条件１]
         // 算出した角度が左右の境界ベクトルよりも傾いているかどうか
@@ -67,7 +86,7 @@ public class EnemyVisibility : MonoBehaviour
         // [条件２]
         // プレイヤーとエネミーの距離が視界の距離よりも離れているかどうか
         // memo : 離れている→視界の範囲外　離れていない→視界の範囲内
-        if (dot < (angle * 0.5f) && playerToEnemy.sqrMagnitude < distance * distance)
+        if (dot < (angle * 0.5f) && raycastHit.distance < distance)
         {
             // プレイヤーを見つけた
             return true;

--- a/pro_builder_test/Assets/Mitsumaru/Scripts/EnemyVisibility.cs
+++ b/pro_builder_test/Assets/Mitsumaru/Scripts/EnemyVisibility.cs
@@ -32,15 +32,6 @@ public class EnemyVisibility : MonoBehaviour
     {
         // 境界ベクトルを作成
         CreateBorderVector();
-
-        if (IsPlayerDiscover())
-        {
-            Debug.Log("AAA");
-        }
-        else
-        {
-            Debug.Log("BBB");
-        }
     }
 
     /// <summary>

--- a/pro_builder_test/Assets/Mitsumaru/TestScene_Mitsumaru.unity
+++ b/pro_builder_test/Assets/Mitsumaru/TestScene_Mitsumaru.unity
@@ -458,6 +458,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 756798316}
+  - component: {fileID: 756798317}
   m_Layer: 0
   m_Name: Chaser
   m_TagString: Untagged
@@ -479,6 +480,20 @@ Transform:
   m_Father: {fileID: 108899794}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &756798317
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 756798315}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bdf1023497152fc45a5af7ac60f399a7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  navMeshAgent: {fileID: 283617947}
+  player: {fileID: 1971433529}
 --- !u!1001 &873186042
 PrefabInstance:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
間に障害物があるかどうかの判定を追加し忘れていた。
エネミーからプレイヤーに向かってレイを飛ばし、障害物がなければ視界の範囲内にいるかどうかの判定を行う。

【確認ファイル】
EnemyVisibility.cs