### PR TITLE
敵の徘徊と追跡を切り替える処理を作成 

### DIFF
--- a/pro_builder_test/Assets/Mitsumaru/Scripts/EnemyBehaviorSwitcher.cs
+++ b/pro_builder_test/Assets/Mitsumaru/Scripts/EnemyBehaviorSwitcher.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// エネミーの状態を状況に応じて切り替える
+/// </summary>
+public class EnemyBehaviorSwitcher : MonoBehaviour
+{
+    // エネミーの視界判定クラス
+    [SerializeField]
+    EnemyVisibility enemyVisibility = default;
+
+    // 徘徊
+    [SerializeField]
+    GameObject move = default;
+
+    // 追跡
+    [SerializeField]
+    GameObject chaser = default;
+
+    /// <summary>
+    /// 更新
+    /// </summary>
+    void Update()
+    {
+        // プレイヤーを発見した
+        if (enemyVisibility.IsPlayerDiscover())
+        {
+            // 追跡を開始する
+            chaser.SetActive(true);
+            // 徘徊を中断する
+            move.SetActive(false);
+        }
+        // プレイヤーを発見していない、もしくは見失った
+        else
+        {
+            // 追跡を諦める
+            chaser.SetActive(false);
+            // 徘徊を再開する
+            move.SetActive(true);
+        }
+    }
+}

--- a/pro_builder_test/Assets/Mitsumaru/Scripts/EnemyBehaviorSwitcher.cs.meta
+++ b/pro_builder_test/Assets/Mitsumaru/Scripts/EnemyBehaviorSwitcher.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 61a2f36f1b383fd48af463a2ca61d7d5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/pro_builder_test/Assets/Mitsumaru/Scripts/EnemyChaser.cs
+++ b/pro_builder_test/Assets/Mitsumaru/Scripts/EnemyChaser.cs
@@ -16,6 +16,19 @@ public class EnemyChaser : MonoBehaviour
     [SerializeField]
     Transform player = default;
 
+    // 移動スピード
+    [SerializeField]
+    float moveSpeed = default;
+
+    /// <summary>
+    /// 開始
+    /// </summary>
+    void OnEnable()
+    {
+        // 移動スピードをセット
+        navMeshAgent.speed = moveSpeed;
+    }
+
     /// <summary>
     /// 更新
     /// </summary>

--- a/pro_builder_test/Assets/Mitsumaru/Scripts/EnemyMover.cs
+++ b/pro_builder_test/Assets/Mitsumaru/Scripts/EnemyMover.cs
@@ -16,14 +16,20 @@ public class EnemyMover : MonoBehaviour
     [SerializeField]
     List<Vector3> targetPositions = default;
 
+    // 移動スピード
+    [SerializeField]
+    float moveSpeed = default;
+
     // 現在の目標位置のリスト番号
     int currentIndex = 0;
 
     /// <summary>
     /// 開始
     /// </summary>
-    void Start()
+    void OnEnable()
     {
+        // 移動スピードをセット
+        navMeshAgent.speed = moveSpeed;
         // 一番最初の位置を設定
         navMeshAgent.SetDestination(GetNextTargetPos());
     }

--- a/pro_builder_test/Assets/Mitsumaru/TestScene_Mitsumaru.unity
+++ b/pro_builder_test/Assets/Mitsumaru/TestScene_Mitsumaru.unity
@@ -135,6 +135,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 108899794}
+  - component: {fileID: 108899795}
   m_Layer: 0
   m_Name: Behavior
   m_TagString: Untagged
@@ -159,6 +160,21 @@ Transform:
   m_Father: {fileID: 283617944}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &108899795
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 108899793}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 61a2f36f1b383fd48af463a2ca61d7d5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  enemyVisibility: {fileID: 283617941}
+  move: {fileID: 1355318079}
+  chaser: {fileID: 756798315}
 --- !u!1 &126985832 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 938179186347872562, guid: 8b9192f355793c2438107ca19a4a26ee,
@@ -245,8 +261,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   player: {fileID: 1971433529}
-  angle: 45
-  distance: 3.5
+  angle: 120
+  distance: 10
 --- !u!23 &283617942
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -319,7 +335,7 @@ NavMeshAgent:
   m_Enabled: 1
   m_AgentTypeID: 0
   m_Radius: 0.38
-  m_Speed: 3.5
+  m_Speed: 4
   m_Acceleration: 8
   avoidancePriority: 50
   m_AngularSpeed: 120
@@ -494,6 +510,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   navMeshAgent: {fileID: 283617947}
   player: {fileID: 1971433529}
+  moveSpeed: 7
 --- !u!1001 &873186042
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1080,7 +1097,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1355318079}
-  m_Enabled: 0
+  m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 75163a55b13402b4aab05c288152c845, type: 3}
   m_Name: 
@@ -1092,6 +1109,7 @@ MonoBehaviour:
   - {x: -17.71, y: 0, z: 11.71}
   - {x: -14, y: 0, z: 2.8}
   - {x: 3.75, y: 0, z: 9.07}
+  moveSpeed: 4
 --- !u!1 &1731916098 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 938179186347872562, guid: f8a563e2f9aa4864d9db25e6b2fcaae8,


### PR DESCRIPTION
敵の視界の判定から徘徊と追跡を切り替える処理を作成した。
発見した瞬間に追跡、見失った瞬間に徘徊を行うようになっている。
徘徊と追跡でそれぞれ移動スピードを変更できるようにした。

【確認ファイル】
EnemyBehaviorSwitcher.cs
EnemyChaser.cs
EnemyMover.cs